### PR TITLE
Add border in order to show current path in floating mode

### DIFF
--- a/lua/plugins/oil.lua
+++ b/lua/plugins/oil.lua
@@ -6,6 +6,9 @@ return {
         view_options = {
             show_hidden = true,
         },
+        float = {
+            border = "single",
+        },
     },
     -- Optional dependencies
     dependencies = { { "echasnovski/mini.icons", opts = {} } },


### PR DESCRIPTION
Recently the current path is not being shown in floating mode for Oil plugin. This is documented in [this](https://github.com/stevearc/oil.nvim/issues/683) issue. In order to fix the problem, border has to be changed.